### PR TITLE
Add search support on backend

### DIFF
--- a/services/question-service/handlers/list.go
+++ b/services/question-service/handlers/list.go
@@ -266,22 +266,21 @@ func getKeywordsFromTitle(title string) []string {
 }
 
 // titleContainsKeywords Check if title contains all keywords
-func titleContainsKeywords(title string, keywords []string) bool {
+func titleContainsKeywords(title string, queryKeywords []string) bool {
 	// TODO: Implement using trie for better performance
 	titleWords := strings.Fields(strings.ToLower(strings.TrimSpace(title)))
 
 	// Iterate through each keyword.
-	for _, keyword := range keywords {
-		keyword = strings.ToLower(strings.TrimSpace(keyword)) // Normalize the keyword.
+	for _, queryKeyword := range queryKeywords {
 		matched := false
-		// Check if the keyword is a prefix of any word in the title.
+		// Check if the queryKeyword is a prefix of any word in the title.
 		for _, titleWord := range titleWords {
-			if strings.HasPrefix(titleWord, keyword) {
+			if strings.HasPrefix(titleWord, queryKeyword) {
 				matched = true
 				break
 			}
 		}
-		// If the keyword is not a prefix of any title word, return false.
+		// If the queryKeyword is not a prefix of any title word, return false.
 		if !matched {
 			return false
 		}

--- a/services/question-service/handlers/list.go
+++ b/services/question-service/handlers/list.go
@@ -260,12 +260,12 @@ func paginateResults(results []*firestore.DocumentSnapshot, offset, limit int) [
 	return results[start:end]
 }
 
-// GetKeywordsFromTitle Get keywords from question's title
+// getKeywordsFromTitle Get keywords from question's title
 func getKeywordsFromTitle(title string) []string {
 	return strings.Split(strings.ToLower(strings.TrimSpace(title)), " ")
 }
 
-// TitleContainsKeywords Check if title contains all keywords
+// titleContainsKeywords Check if title contains all keywords
 func titleContainsKeywords(title string, keywords []string) bool {
 	titleWordsSet := make(map[string]bool)
 	titleWords := strings.Split(strings.ToLower(strings.TrimSpace(title)), " ")

--- a/services/question-service/handlers/list.go
+++ b/services/question-service/handlers/list.go
@@ -208,7 +208,7 @@ func (s *Service) ListQuestions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Calculate pagination info
-	totalCount := len(questions)
+	totalCount := len(filteredResults)
 	totalPages := (totalCount + limit - 1) / limit
 	currentPage := (offset / limit) + 1
 	if len(questions) == 0 {
@@ -267,14 +267,22 @@ func getKeywordsFromTitle(title string) []string {
 
 // titleContainsKeywords Check if title contains all keywords
 func titleContainsKeywords(title string, keywords []string) bool {
-	titleWordsSet := make(map[string]bool)
-	titleWords := strings.Split(strings.ToLower(strings.TrimSpace(title)), " ")
-	for _, titleWord := range titleWords {
-		titleWordsSet[titleWord] = true
-	}
+	// TODO: Implement using trie for better performance
+	titleWords := strings.Fields(strings.ToLower(strings.TrimSpace(title)))
 
+	// Iterate through each keyword.
 	for _, keyword := range keywords {
-		if !titleWordsSet[keyword] {
+		keyword = strings.ToLower(strings.TrimSpace(keyword)) // Normalize the keyword.
+		matched := false
+		// Check if the keyword is a prefix of any word in the title.
+		for _, titleWord := range titleWords {
+			if strings.HasPrefix(titleWord, keyword) {
+				matched = true
+				break
+			}
+		}
+		// If the keyword is not a prefix of any title word, return false.
+		if !matched {
 			return false
 		}
 	}

--- a/services/question-service/handlers/list.go
+++ b/services/question-service/handlers/list.go
@@ -59,7 +59,7 @@ func (s *Service) ListQuestions(w http.ResponseWriter, r *http.Request) {
 		for _, complexityStr := range complexityStrs {
 			complexityType, err := models.ParseComplexity(complexityStr)
 			if err != nil {
-				http.Error(w, "Failed to filter by complexity: "+err.Error(), http.StatusInternalServerError)
+				http.Error(w, "Failed to filter by complexity: "+err.Error(), http.StatusBadRequest)
 				return
 			}
 			complexityInts = append(complexityInts, int(complexityType))

--- a/services/question-service/handlers/list.go
+++ b/services/question-service/handlers/list.go
@@ -51,12 +51,6 @@ func (s *Service) ListQuestions(w http.ResponseWriter, r *http.Request) {
 
 	query := s.Client.Collection("questions").Query
 
-	// Filtering by title
-	titleParam := r.URL.Query().Get("title")
-	if titleParam != "" {
-		query = query.Where("title", "==", titleParam)
-	}
-
 	// Filtering by complexity (multi-select)
 	complexityParam := r.URL.Query().Get("complexity")
 	if complexityParam != "" {
@@ -73,15 +67,7 @@ func (s *Service) ListQuestions(w http.ResponseWriter, r *http.Request) {
 		query = query.Where("complexity", "in", complexityInts)
 	}
 
-	// Filtering by categories (multi-select): Partially using array-contains-any first
-	categoriesParam := r.URL.Query().Get("categories")
-	var categories []string
-	if categoriesParam != "" {
-		categories = strings.Split(categoriesParam, ",")
-		query = query.Where("categories", "array-contains-any", categories)
-	}
-
-	// Sorting
+	// Sorting (Generalisable to multiple fields but limited by firebase composite indexes)
 	sortFieldsParam := r.URL.Query()["sortField"]
 	sortValuesParam := r.URL.Query()["sortValue"]
 
@@ -123,12 +109,27 @@ func (s *Service) ListQuestions(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to to get fetch questions: "+err.Error(), http.StatusInternalServerError)
 	}
 
+	// Parse categories from query param (multi-select)
+	categoriesParam := r.URL.Query().Get("categories")
+	var categories []string
+	if categoriesParam != "" {
+		categories = strings.Split(categoriesParam, ",")
+	}
+
+	// Parse title keywords from title query param
+	titleParam := r.URL.Query().Get("title")
+	var keywordsQuery []string
+	if titleParam != "" {
+		keywordsQuery = getKeywordsFromTitle(titleParam)
+	}
+
 	// Filter the results to check if the document contains all categories (implementation of array-contains-all)
 	var filteredResults []*firestore.DocumentSnapshot
-	if categories != nil {
-		for _, doc := range results {
-			data := doc.Data()
+	for _, doc := range results {
+		data := doc.Data()
 
+		var passedCategoryFilterDoc *firestore.DocumentSnapshot
+		if categories != nil {
 			// Retrieve the "categories" field from the document and convert to []string
 			if docCategories, ok := data["categories"].([]interface{}); ok {
 				stringCategories := make([]string, len(docCategories))
@@ -139,12 +140,33 @@ func (s *Service) ListQuestions(w http.ResponseWriter, r *http.Request) {
 				}
 
 				if containsAllCategoriesSet(stringCategories, categories) {
-					filteredResults = append(filteredResults, doc)
+					passedCategoryFilterDoc = doc
 				}
 			}
+		} else {
+			passedCategoryFilterDoc = doc
 		}
-	} else {
-		filteredResults = results
+
+		if passedCategoryFilterDoc == nil {
+			continue
+		}
+
+		var passedTitleKeywordsFilterDoc *firestore.DocumentSnapshot
+		if keywordsQuery != nil {
+			if docTitle, ok := data["title"].(string); ok {
+				if titleContainsKeywords(docTitle, keywordsQuery) {
+					passedTitleKeywordsFilterDoc = passedCategoryFilterDoc
+				}
+			}
+		} else {
+			passedTitleKeywordsFilterDoc = passedCategoryFilterDoc
+		}
+
+		if passedTitleKeywordsFilterDoc == nil {
+			continue
+		}
+
+		filteredResults = append(filteredResults, passedTitleKeywordsFilterDoc)
 	}
 
 	// Pagination
@@ -186,9 +208,12 @@ func (s *Service) ListQuestions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Calculate pagination info
-	totalCount := len(filteredResults)
+	totalCount := len(questions)
 	totalPages := (totalCount + limit - 1) / limit
 	currentPage := (offset / limit) + 1
+	if len(questions) == 0 {
+		currentPage = 0
+	}
 	hasNextPage := totalPages > currentPage
 
 	// Construct response
@@ -233,6 +258,27 @@ func paginateResults(results []*firestore.DocumentSnapshot, offset, limit int) [
 		end = len(results)
 	}
 	return results[start:end]
+}
+
+// GetKeywordsFromTitle Get keywords from question's title
+func getKeywordsFromTitle(title string) []string {
+	return strings.Split(strings.ToLower(strings.TrimSpace(title)), " ")
+}
+
+// TitleContainsKeywords Check if title contains all keywords
+func titleContainsKeywords(title string, keywords []string) bool {
+	titleWordsSet := make(map[string]bool)
+	titleWords := strings.Split(strings.ToLower(strings.TrimSpace(title)), " ")
+	for _, titleWord := range titleWords {
+		titleWordsSet[titleWord] = true
+	}
+
+	for _, keyword := range keywords {
+		if !titleWordsSet[keyword] {
+			return false
+		}
+	}
+	return true
 }
 
 //Manual test cases


### PR DESCRIPTION
Supports case-insensitive search by keywords (extracted by splitting by spaces).

Approach considered by not viable:
* Store "title words" in database and search using query = query.Where("title", "array-contains", titleParam)
* Firestore/Firebase does not support this as it is essential array-contains-all keywords in array titleParam
* Cannot chain query array-contains each keyword, since Firebase also does not allow this
* Similar to self-implementation of array-contains-all when filtering by "categories"
* Since we still need to self-implement, it defeats the purpose of storing title words in firebase
* Can just parse and get the keywords whenever we search for title

Approach adopted:
* Self-implement "title words" array-contains-all "search keywords"

TODO:
* implement trie for faster title search