### PR TITLE
User Registration Page

### DIFF
--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,2 +1,3 @@
 # Replace with the corresponding url, credentials and endpoint
 NEXT_PUBLIC_API_URL="http://localhost:8080/"
+NEXT_PUBLIC_USER_SERVICE_URL="http://localhost:3001/"

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -29,6 +29,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import TextArea from "antd/es/input/TextArea";
 import {loginUser} from '@/app/services/user'
+import {setToken} from '@/app/services/login-store'
 
 type InputFields = {
   email?: string
@@ -43,9 +44,10 @@ export default function Home() {
       return;
     }
     loginUser(email, password).then(jwt => {
-      console.log(jwt);
+      console.log("login successful");
+      setToken(jwt);
     }).catch(err => {
-      console.error(err)
+      console.error(err);
     })
   }
 

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -28,7 +28,7 @@ import "./styles.scss";
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import TextArea from "antd/es/input/TextArea";
-import { title } from "process";
+import {loginUser} from '@/app/services/user'
 
 type InputFields = {
   email?: string
@@ -36,6 +36,19 @@ type InputFields = {
 }
 
 export default function Home() {
+  function submitDetails({email, password}: InputFields): void {
+    if (!email || email === "" ||
+      !password || password === ""
+    ) {
+      return;
+    }
+    loginUser(email, password).then(jwt => {
+      console.log(jwt);
+    }).catch(err => {
+      console.error(err)
+    })
+  }
+
   return (
     <div>
       <Layout>
@@ -45,6 +58,7 @@ export default function Home() {
             <h1>Login</h1>
             <Form
               name="basic"
+              onFinish={submitDetails}
             >
               <Form.Item<InputFields>
                 name="email"  
@@ -59,13 +73,13 @@ export default function Home() {
                 name="password"  
                 rules={[{required: true}]}
               >
-                <Input
+                <Input.Password
                   placeholder="Password"
                 />
               </Form.Item>
 
               <Form.Item>
-                <Button type="primary">
+                <Button type="primary" htmlType="submit">
                   Login
                 </Button>
               </Form.Item>

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -64,7 +64,10 @@ export default function Home() {
             >
               <Form.Item<InputFields>
                 name="email"  
-                rules={[{required: true}]}
+                rules={[{
+                    required: true, 
+                    message: "Please provide your email."
+                  }]}
               >
                 <Input
                   placeholder="Email"
@@ -73,7 +76,10 @@ export default function Home() {
 
               <Form.Item<InputFields>
                 name="password"  
-                rules={[{required: true}]}
+                rules={[{
+                  required: true, 
+                  message: "Please enter your password."
+                }]}
               >
                 <Input.Password
                   placeholder="Password"

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+import Header from "@/components/Header/header";
+import {
+  Button,
+  Col,
+  Input,
+  Layout,
+  message,
+  Pagination,
+  PaginationProps,
+  Row,
+  Select,
+  Table,
+  TableProps,
+  Tabs,
+  Tag,
+  Modal,
+  Form,
+} from "antd";
+import { Content } from "antd/es/layout/layout";
+import {
+  DeleteOutlined,
+  EditOutlined,
+  PlusCircleOutlined,
+  SearchOutlined,
+} from "@ant-design/icons";
+import "./styles.scss";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import TextArea from "antd/es/input/TextArea";
+import { title } from "process";
+
+type InputFields = {
+  email?: string
+  password?: string
+}
+
+export default function Home() {
+  return (
+    <div>
+      <Layout>
+        <Header/>
+        <Content>
+          <div className="login-card">
+            <h1>Login</h1>
+            <Form
+              name="basic"
+            >
+              <Form.Item<InputFields>
+                name="email"  
+                rules={[{required: true}]}
+              >
+                <Input
+                  placeholder="Email"
+                />
+              </Form.Item>
+
+              <Form.Item<InputFields>
+                name="password"  
+                rules={[{required: true}]}
+              >
+                <Input
+                  placeholder="Password"
+                />
+              </Form.Item>
+
+              <Form.Item>
+                <Button type="primary">
+                  Login
+                </Button>
+              </Form.Item>
+            </Form>
+            <p>
+              Let me <Link
+                href="/register"
+              >register</Link>
+            </p>
+          </div>
+        </Content>
+      </Layout>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -17,8 +17,8 @@ import {setToken} from '@/app/services/login-store'
 import { useRouter } from "next/navigation";
 
 type InputFields = {
-  email?: string
-  password?: string
+  email: string
+  password: string
 }
 
 export default function Home() {
@@ -35,11 +35,6 @@ export default function Home() {
   };
 
   function submitDetails({email, password}: InputFields): void {
-    if (!email || email === "" ||
-      !password || password === ""
-    ) {
-      return;
-    }
     loginUser(email, password).then(jwt => {
       successMessage("Login successful")
       setToken(jwt);
@@ -65,12 +60,15 @@ export default function Home() {
             >
               <Form.Item<InputFields>
                 name="email"  
-                rules={[{
+                rules={[
+                  {
                     required: true, 
                     message: "Please provide your email."
-                  }]}
+                  },
+                ]}
               >
                 <Input
+                  type="email"
                   placeholder="Email"
                 />
               </Form.Item>

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -30,6 +30,7 @@ import Link from "next/link";
 import TextArea from "antd/es/input/TextArea";
 import {loginUser} from '@/app/services/user'
 import {setToken} from '@/app/services/login-store'
+import { useRouter } from "next/navigation";
 
 type InputFields = {
   email?: string
@@ -37,6 +38,18 @@ type InputFields = {
 }
 
 export default function Home() {
+  
+  const [isLoginFailed, setIsLoginFailed] = useState(false);
+  const router = useRouter();
+  const [messageApi, contextHolder] = message.useMessage();
+  
+  const successMessage = (message: string) => {
+    messageApi.open({
+      type: "success",
+      content: message,
+    });
+  };
+
   function submitDetails({email, password}: InputFields): void {
     if (!email || email === "" ||
       !password || password === ""
@@ -44,15 +57,19 @@ export default function Home() {
       return;
     }
     loginUser(email, password).then(jwt => {
-      console.log("login successful");
+      successMessage("Login successful")
       setToken(jwt);
+      router.push("/");
+
     }).catch(err => {
       console.error(err);
+      setIsLoginFailed(true);
     })
   }
 
   return (
-    <div>
+    <>
+      {contextHolder}
       <Layout>
         <Header/>
         <Content>
@@ -86,6 +103,11 @@ export default function Home() {
                 />
               </Form.Item>
 
+              <div 
+                style={{visibility: isLoginFailed ? "visible" : "hidden"}} 
+                className="registration-failed-text">This email/username is not valid
+              </div>
+
               <Form.Item>
                 <Button type="primary" htmlType="submit">
                   Login
@@ -100,6 +122,6 @@ export default function Home() {
           </div>
         </Content>
       </Layout>
-    </div>
+    </>
   );
 }

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -2,28 +2,12 @@
 import Header from "@/components/Header/header";
 import {
   Button,
-  Col,
   Input,
   Layout,
   message,
-  Pagination,
-  PaginationProps,
-  Row,
-  Select,
-  Table,
-  TableProps,
-  Tabs,
-  Tag,
-  Modal,
   Form,
 } from "antd";
 import { Content } from "antd/es/layout/layout";
-import {
-  DeleteOutlined,
-  EditOutlined,
-  PlusCircleOutlined,
-  SearchOutlined,
-} from "@ant-design/icons";
 import "./styles.scss";
 import { useEffect, useState } from "react";
 import Link from "next/link";

--- a/apps/frontend/src/app/login/styles.scss
+++ b/apps/frontend/src/app/login/styles.scss
@@ -1,0 +1,76 @@
+.layout {
+  background: white;
+}
+
+.content {
+  background: white;
+}
+
+.content-card {
+  margin: 4rem 8rem;
+  padding: 2rem 4rem;
+  background-color: white;
+  min-height: 100vh;
+  border-radius: 30px;
+  box-shadow: 0px 10px 60px rgba(226, 236, 249, 0.5);
+}
+
+.login-card {
+  /* Rectangle 6698 */
+  margin: 4rem auto;
+  padding: 2rem 4rem;  
+  box-sizing: border-box;
+  max-width: 30rem;
+  background: #FFFFFF;
+  border: 2px solid #8A817C;
+  box-shadow: 3px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 15px;
+}
+
+.content-row-1 {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.content-title {
+  //   font-family: "Poppins";
+  //   font-style: normal;
+  font-weight: 600;
+  font-size: 22px;
+  line-height: 33px;
+  letter-spacing: -0.01em;
+  color: #000000;
+}
+
+.content-filter {
+  margin: 1.5rem 0;
+}
+
+.edit-button {
+  margin-right: 0.5rem;
+}
+
+.filter-button {
+  margin-left: 8px;
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.02) !important;
+}
+
+.clear-button {
+  width: 100%;
+}
+
+.categories-multi-select,
+.difficulty-select,
+.order-select {
+  width: 100%;
+}
+
+.create-title,
+.new-problem-categories-multi-select,
+.new-problem-difficulty-select,
+.create-description,
+.create-problem-id {
+  width: 100%;
+  margin: 5px;
+}

--- a/apps/frontend/src/app/login/styles.scss
+++ b/apps/frontend/src/app/login/styles.scss
@@ -27,6 +27,11 @@
   border-radius: 15px;
 }
 
+.registration-failed-text {
+  color: #f02849;
+  font-size: 13px;
+}
+
 .content-row-1 {
   display: flex;
   flex-direction: row;

--- a/apps/frontend/src/app/register/page.tsx
+++ b/apps/frontend/src/app/register/page.tsx
@@ -28,15 +28,27 @@ import "./styles.scss";
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import TextArea from "antd/es/input/TextArea";
-import { title } from "process";
+import { createUser } from '@/app/services/user'
 
 type InputFields = {
+  username?: string
   email?: string
   password?: string
   confirmPassword?: string
 }
 
 export default function Home() {
+  function submitDetails({username, email, password}: InputFields): void {
+    if (!username || username === "" ||
+      !email || email === "" ||
+      !password || password === ""
+    ) {
+      return;
+    }
+    createUser(username, email, password).catch(err => {
+      console.error(err)
+    })
+  }
   return (
     <div>
       <Layout>
@@ -48,7 +60,18 @@ export default function Home() {
             <Form
               name="basic"
               style={{ margin: "auto" }}
+              onFinish={submitDetails}
             >
+              
+              <Form.Item<InputFields>
+                name="username"  
+                rules={[{required: true}]}
+              >
+                <Input
+                  placeholder="Username"
+                />
+              </Form.Item>
+
               <Form.Item<InputFields>
                 name="email"  
                 rules={[{required: true}]}
@@ -62,7 +85,7 @@ export default function Home() {
                 name="password"  
                 rules={[{required: true}]}
               >
-                <Input
+                <Input.Password
                   placeholder="Password"
                 />
               </Form.Item>
@@ -71,13 +94,13 @@ export default function Home() {
                 name="confirmPassword"
                 rules={[{required: true}]}
               >
-                <Input
+                <Input.Password
                   placeholder="Confirm Password"
                 />
               </Form.Item>
 
               <Form.Item>
-                <Button type="primary">
+                <Button type="primary" htmlType="submit">
                   Register
                 </Button>
               </Form.Item>

--- a/apps/frontend/src/app/register/page.tsx
+++ b/apps/frontend/src/app/register/page.tsx
@@ -16,10 +16,10 @@ import { createUser } from '@/app/services/user'
 import { useRouter } from "next/navigation";
 
 type InputFields = {
-  username?: string
-  email?: string
-  password?: string
-  confirmPassword?: string
+  username: string
+  email: string
+  password: string
+  confirmPassword: string
 }
 
 export default function Home() {
@@ -36,12 +36,6 @@ export default function Home() {
   };
 
   function submitDetails({username, email, password}: InputFields): void {
-    if (!username || username === "" ||
-      !email || email === "" ||
-      !password || password === ""
-    ) {
-      return;
-    }
     createUser(username, email, password)
     .then(() => {
       successMessage("Account successfully created")
@@ -68,10 +62,16 @@ export default function Home() {
               
               <Form.Item<InputFields>
                 name="username"  
-                rules={[{
-                  required: true, 
-                  message: "You must provide a username."
-                }]}
+                rules={[
+                  {
+                    required: true,
+                    message: "You must provide a username."
+                  },
+                  {
+                    pattern: /^\S+$/,
+                    message: "Please provide a valid username."
+                  },
+                ]}
               >
                 <Input
                   placeholder="Username"
@@ -80,12 +80,19 @@ export default function Home() {
 
               <Form.Item<InputFields>
                 name="email"  
-                rules={[{
-                  required: true, 
-                  message: "You must provide an email."
-                }]}
+                rules={[
+                  {
+                    required: true, 
+                    message: "You must provide an email."
+                  },
+                  {
+                    type: "email",
+                    message: "Please provide a valid email address."
+                  },
+                ]}
               >
                 <Input
+                  type="email"
                   placeholder="Email"
                 />
               </Form.Item>

--- a/apps/frontend/src/app/register/page.tsx
+++ b/apps/frontend/src/app/register/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+import Header from "@/components/Header/header";
+import {
+  Button,
+  Col,
+  Input,
+  Layout,
+  message,
+  Pagination,
+  PaginationProps,
+  Row,
+  Select,
+  Table,
+  TableProps,
+  Tabs,
+  Tag,
+  Modal,
+  Form,
+} from "antd";
+import { Content } from "antd/es/layout/layout";
+import {
+  DeleteOutlined,
+  EditOutlined,
+  PlusCircleOutlined,
+  SearchOutlined,
+} from "@ant-design/icons";
+import "./styles.scss";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import TextArea from "antd/es/input/TextArea";
+import { title } from "process";
+
+type InputFields = {
+  email?: string
+  password?: string
+  confirmPassword?: string
+}
+
+export default function Home() {
+  return (
+    <div>
+      <Layout>
+        <Header/>
+        <Content>
+          <div className="login-card">
+            <h1>Register</h1>
+
+            <Form
+              name="basic"
+              style={{ margin: "auto" }}
+            >
+              <Form.Item<InputFields>
+                name="email"  
+                rules={[{required: true}]}
+              >
+                <Input
+                  placeholder="Email"
+                />
+              </Form.Item>
+
+              <Form.Item<InputFields>
+                name="password"  
+                rules={[{required: true}]}
+              >
+                <Input
+                  placeholder="Password"
+                />
+              </Form.Item>
+
+              <Form.Item<InputFields>
+                name="confirmPassword"
+                rules={[{required: true}]}
+              >
+                <Input
+                  placeholder="Confirm Password"
+                />
+              </Form.Item>
+
+              <Form.Item>
+                <Button type="primary">
+                  Register
+                </Button>
+              </Form.Item>
+            </Form>
+            <p>
+              Let me <Link
+                href="/login"
+              >login</Link>
+            </p>
+          </div>
+        </Content>
+      </Layout>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/register/page.tsx
+++ b/apps/frontend/src/app/register/page.tsx
@@ -29,6 +29,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import TextArea from "antd/es/input/TextArea";
 import { createUser } from '@/app/services/user'
+import { useRouter } from "next/navigation";
 
 type InputFields = {
   username?: string
@@ -38,6 +39,18 @@ type InputFields = {
 }
 
 export default function Home() {
+
+  const [isRegistrationFailed, setIsRegistrationFailed] = useState(false);
+  const router = useRouter();
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const successMessage = (message: string) => {
+    messageApi.open({
+      type: "success",
+      content: message,
+    });
+  };
+
   function submitDetails({username, email, password}: InputFields): void {
     if (!username || username === "" ||
       !email || email === "" ||
@@ -45,12 +58,18 @@ export default function Home() {
     ) {
       return;
     }
-    createUser(username, email, password).catch(err => {
-      console.error(err)
+    createUser(username, email, password)
+    .then(() => {
+      successMessage("Account successfully created")
+      router.push("/login");
+    }).catch(err => {
+      console.log(err);
+      setIsRegistrationFailed(true);
     })
   }
   return (
-    <div>
+    <>
+      {contextHolder}
       <Layout>
         <Header/>
         <Content>
@@ -120,6 +139,11 @@ export default function Home() {
                 />
               </Form.Item>
 
+              <div 
+                style={{visibility: isRegistrationFailed ? "visible" : "hidden"}} 
+                className="registration-failed-text">A user with the same email/username already exists
+              </div>
+
               <Form.Item>
                 <Button type="primary" htmlType="submit">
                   Register
@@ -134,6 +158,6 @@ export default function Home() {
           </div>
         </Content>
       </Layout>
-    </div>
+    </>
   );
 }

--- a/apps/frontend/src/app/register/page.tsx
+++ b/apps/frontend/src/app/register/page.tsx
@@ -2,28 +2,12 @@
 import Header from "@/components/Header/header";
 import {
   Button,
-  Col,
   Input,
   Layout,
   message,
-  Pagination,
-  PaginationProps,
-  Row,
-  Select,
-  Table,
-  TableProps,
-  Tabs,
-  Tag,
-  Modal,
   Form,
 } from "antd";
 import { Content } from "antd/es/layout/layout";
-import {
-  DeleteOutlined,
-  EditOutlined,
-  PlusCircleOutlined,
-  SearchOutlined,
-} from "@ant-design/icons";
 import "./styles.scss";
 import { useEffect, useState } from "react";
 import Link from "next/link";

--- a/apps/frontend/src/app/register/page.tsx
+++ b/apps/frontend/src/app/register/page.tsx
@@ -65,7 +65,10 @@ export default function Home() {
               
               <Form.Item<InputFields>
                 name="username"  
-                rules={[{required: true}]}
+                rules={[{
+                  required: true, 
+                  message: "You must provide a username."
+                }]}
               >
                 <Input
                   placeholder="Username"
@@ -74,7 +77,10 @@ export default function Home() {
 
               <Form.Item<InputFields>
                 name="email"  
-                rules={[{required: true}]}
+                rules={[{
+                  required: true, 
+                  message: "You must provide an email."
+                }]}
               >
                 <Input
                   placeholder="Email"
@@ -83,7 +89,10 @@ export default function Home() {
 
               <Form.Item<InputFields>
                 name="password"  
-                rules={[{required: true}]}
+                rules={[{
+                  required: true, 
+                  message: "You must provide a password."
+                }]}
               >
                 <Input.Password
                   placeholder="Password"
@@ -92,7 +101,19 @@ export default function Home() {
 
               <Form.Item<InputFields>
                 name="confirmPassword"
-                rules={[{required: true}]}
+                rules={[
+                  {
+                    required: true, 
+                    message: "Please confirm your password."
+                  },
+                  ({getFieldValue}) => ({
+                    validator: async (r, confirmPassword) => {
+                      if (!!confirmPassword && getFieldValue("password") !== confirmPassword) {
+                        throw new Error("Passwords do not match")
+                      }
+                    }
+                  })
+                ]}
               >
                 <Input.Password
                   placeholder="Confirm Password"

--- a/apps/frontend/src/app/register/styles.scss
+++ b/apps/frontend/src/app/register/styles.scss
@@ -1,0 +1,76 @@
+.layout {
+  background: white;
+}
+
+.content {
+  background: white;
+}
+
+.content-card {
+  margin: 4rem 8rem;
+  padding: 2rem 4rem;
+  background-color: white;
+  min-height: 100vh;
+  border-radius: 30px;
+  box-shadow: 0px 10px 60px rgba(226, 236, 249, 0.5);
+}
+
+.login-card {
+  /* Rectangle 6698 */
+  margin: 4rem auto;
+  padding: 2rem 4rem;  
+  box-sizing: border-box;
+  max-width: 30rem;
+  background: #FFFFFF;
+  border: 2px solid #8A817C;
+  box-shadow: 3px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 15px;
+}
+
+.content-row-1 {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.content-title {
+  //   font-family: "Poppins";
+  //   font-style: normal;
+  font-weight: 600;
+  font-size: 22px;
+  line-height: 33px;
+  letter-spacing: -0.01em;
+  color: #000000;
+}
+
+.content-filter {
+  margin: 1.5rem 0;
+}
+
+.edit-button {
+  margin-right: 0.5rem;
+}
+
+.filter-button {
+  margin-left: 8px;
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.02) !important;
+}
+
+.clear-button {
+  width: 100%;
+}
+
+.categories-multi-select,
+.difficulty-select,
+.order-select {
+  width: 100%;
+}
+
+.create-title,
+.new-problem-categories-multi-select,
+.new-problem-difficulty-select,
+.create-description,
+.create-problem-id {
+  width: 100%;
+  margin: 5px;
+}

--- a/apps/frontend/src/app/register/styles.scss
+++ b/apps/frontend/src/app/register/styles.scss
@@ -27,6 +27,11 @@
   border-radius: 15px;
 }
 
+.registration-failed-text {
+  color: #f02849;
+  font-size: 13px;
+}
+
 .content-row-1 {
   display: flex;
   flex-direction: row;

--- a/apps/frontend/src/app/services/login-store.ts
+++ b/apps/frontend/src/app/services/login-store.ts
@@ -7,3 +7,9 @@ export function setToken(token: string): void {
 export function getToken(): string {
     return KEY in window.localStorage ? window.localStorage[KEY] : ""
 }
+
+export function deleteToken() {
+    if (KEY in window.localStorage) {
+        window.localStorage.removeItem(KEY);
+    }
+}

--- a/apps/frontend/src/app/services/login-store.ts
+++ b/apps/frontend/src/app/services/login-store.ts
@@ -1,0 +1,9 @@
+const KEY: string = "TOKEN";
+
+export function setToken(token: string): void {
+    window.localStorage[KEY] = token
+}
+
+export function getToken(): string {
+    return KEY in window.localStorage ? window.localStorage[KEY] : ""
+}

--- a/apps/frontend/src/app/services/user.ts
+++ b/apps/frontend/src/app/services/user.ts
@@ -1,4 +1,4 @@
-const USER_SERVICE_URL = "http://localhost:3001"
+const USER_SERVICE_URL = process.env.NEXT_PUBLIC_USER_SERVICE_URL
 
 type UserResponseData = {
   "id": string,
@@ -25,7 +25,7 @@ export async function createUser(username: string, email: string, password: stri
       username, email, password
     }),
   })
-  const res = await fetch(`${USER_SERVICE_URL}/users`, opts)
+  const res = await fetch(`${USER_SERVICE_URL}users`, opts)
 
   if (!res.ok) {
     throw new Error(`User service responded with ${res.status}: ${await res.text()}`)
@@ -39,7 +39,7 @@ export async function loginUser(email: string, password: string): Promise<string
       email, password
     })
   });
-  const res = await fetch(`${USER_SERVICE_URL}/auth/login`, opts);
+  const res = await fetch(`${USER_SERVICE_URL}auth/login`, opts);
 
   if (!res.ok) {
     throw new Error(`User service responded with ${res.status}: ${await res.text()}`);

--- a/apps/frontend/src/app/services/user.ts
+++ b/apps/frontend/src/app/services/user.ts
@@ -1,0 +1,50 @@
+const USER_SERVICE_URL = "http://localhost:3001"
+
+type UserResponseData = {
+  "id": string,
+  "username": string,
+  "email": string,
+  "isAdmin": boolean,
+  "createdAt": string,
+}
+
+function withDefaultHeaders(opts: RequestInit): RequestInit {
+  return {
+    ...opts,
+    headers: {
+      ...(opts.headers ?? {}),
+      "Content-Type": "application/json"
+    },
+  }
+}
+
+export async function createUser(username: string, email: string, password: string): Promise<void> {
+  const opts = withDefaultHeaders({
+    method: "POST",
+    body: JSON.stringify({
+      username, email, password
+    }),
+  })
+  const res = await fetch(`${USER_SERVICE_URL}/users`, opts)
+
+  if (!res.ok) {
+    throw new Error(`User service responded with ${res.status}: ${await res.text()}`)
+  }
+}
+
+export async function loginUser(email: string, password: string): Promise<string> {
+  const opts = withDefaultHeaders({
+    method: "POST",
+    body: JSON.stringify({
+      email, password
+    })
+  });
+  const res = await fetch(`${USER_SERVICE_URL}/auth/login`, opts);
+
+  if (!res.ok) {
+    throw new Error(`User service responded with ${res.status}: ${await res.text()}`);
+  }
+
+  const ret: { "data": { "accessToken": string } } = await res.json();
+  return ret.data.accessToken;
+}


### PR DESCRIPTION
What has been done:

- Pages are navigable in the `/login` and `/register` pages
- Registration and login will fetch from the user-service
- Successful registration will redirect to `login`, successful login will redirect to `/` (question page)
- Login stores the JWT token in `localStorage`
-  Currently no way to "logout", also user can re-login even while logged in 