### PR TITLE
feat: Revamp matching service

### DIFF
--- a/apps/matching-service/.env.example
+++ b/apps/matching-service/.env.example
@@ -1,3 +1,4 @@
 PORT=8081
-MATCH_TIMEOUT=3
+MATCH_TIMEOUT=10
 JWT_SECRET=you-can-replace-this-with-your-own-secret
+REDIS_URL=localhost:6379

--- a/apps/matching-service/README.md
+++ b/apps/matching-service/README.md
@@ -27,8 +27,15 @@ go mod tidy
 - `PORT`: Specifies the port for the WebSocket server. Default is `8081`.
 - `JWT_SECRET`: The secret key used to verify JWT tokens.
 - `MATCH_TIMEOUT`: The time in seconds to wait for a match before timing out.
+- `REDIS_URL`: The URL for the Redis server. Default is `localhost:6379`.
 
-4. Start the WebSocket server:
+4. Start a local redis server:
+
+```bash
+docker run -d -p 6379:6379 redis
+```
+
+5. Start the WebSocket server:
 
 ```bash
 go run main.go
@@ -68,7 +75,9 @@ Client sends matching parameters:
 {
   "type": "match_request",
   "topics": ["Algorithms", "Arrays"],
-  "difficulties": ["Easy", "Medium"]
+  "difficulties": ["Easy", "Medium"],
+  "username": "Jane Doe",
+  "email": "janedoe@gmail.com" // possible to change to user ID in mongodb
 }
 ```
 
@@ -77,9 +86,9 @@ Server response on successful match:
 ```json
 {
   "type": "match_found",
-  "matchID": 67890,
-  "partnerID": 54321,
-  "partnerName": "John Doe"
+  "matchID": "aa41c004e589642402215c2c0a3a165a",
+  "partnerID": 54321, // currently identifying via partner's websocket port --> change to user ID in mongodb
+  "partnerName": "John Doe" // partner username
 }
 ```
 
@@ -99,6 +108,8 @@ If the server encounters an issue during the WebSocket connection or processing,
 Utilize `./tests/websocket-test.html` for a basic debugging interface of the matching service. This HTML file provides an interactive way to test the WebSocket connection, send matching requests, and observe responses from the server.
 
 Make sure to open the HTML file in a web browser while the WebSocket server is running to perform your tests.
+
+You can open one instance of the HTML file in multiple tabs to simulate multiple clients connecting to the server. (In the future: ensure that only one connection is allowed per user)
 
 ## Docker Support
 

--- a/apps/matching-service/README.md
+++ b/apps/matching-service/README.md
@@ -76,8 +76,7 @@ Client sends matching parameters:
   "type": "match_request",
   "topics": ["Algorithms", "Arrays"],
   "difficulties": ["Easy", "Medium"],
-  "username": "Jane Doe",
-  "email": "janedoe@gmail.com" // possible to change to user ID in mongodb
+  "username": "Jane Doe"
 }
 ```
 
@@ -86,9 +85,11 @@ Server response on successful match:
 ```json
 {
   "type": "match_found",
-  "matchID": "aa41c004e589642402215c2c0a3a165a",
-  "partnerID": 54321, // currently identifying via partner's websocket port --> change to user ID in mongodb
-  "partnerName": "John Doe" // partner username
+  "matchId": "1c018916a34c5bee21af0b2670bd6156",
+  "user": "zkb4px",
+  "matchedUser": "JohnDoe",
+  "topic": "Algorithms",
+  "difficulty": "Medium"
 }
 ```
 
@@ -98,6 +99,15 @@ If no match is found after a set period of time, the server will send a timeout 
 {
   "type": "timeout",
   "message": "No match found. Please try again later."
+}
+```
+
+If user has an existing websocket connection and wants to initiate another match, the server will reject the request:
+
+```json
+{
+  "type": "match_rejected",
+  "message": "You are already in a matchmaking queue. Please disconnect before reconnecting."
 }
 ```
 

--- a/apps/matching-service/go.mod
+++ b/apps/matching-service/go.mod
@@ -5,4 +5,10 @@ go 1.23.1
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
+	github.com/redis/go-redis/v9 v9.6.2
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 )

--- a/apps/matching-service/go.sum
+++ b/apps/matching-service/go.sum
@@ -1,4 +1,14 @@
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/redis/go-redis/v9 v9.6.2 h1:w0uvkRbc9KpgD98zcvo5IrVUsn0lXpRMuhNgiHDJzdk=
+github.com/redis/go-redis/v9 v9.6.2/go.mod h1:0C0c6ycQsdpVNQpxb1njEQIqkx5UcsM8FJCQLgE9+RA=

--- a/apps/matching-service/handlers/websocket.go
+++ b/apps/matching-service/handlers/websocket.go
@@ -126,12 +126,12 @@ func waitForResult(ws *websocket.Conn, ctx, timeoutCtx, matchCtx context.Context
 	case <-ctx.Done():
 		log.Println("Matching cancelled")
 		// Cleanup Redis
-		processes.CleanUpUser(processes.GetRedisClient(), username, ctx)
+		processes.CleanUpUser(processes.GetRedisClient(), username, context.Background())
 		return
 	case <-timeoutCtx.Done():
 		log.Println("Connection timed out")
 		// Cleanup Redis
-		processes.CleanUpUser(processes.GetRedisClient(), username, ctx)
+		processes.CleanUpUser(processes.GetRedisClient(), username, context.Background())
 		sendTimeoutResponse(ws)
 		return
 	case <-matchCtx.Done():

--- a/apps/matching-service/handlers/websocket.go
+++ b/apps/matching-service/handlers/websocket.go
@@ -69,6 +69,7 @@ func readMatchRequest(ws *websocket.Conn) (models.MatchRequest, error) {
 	if err := ws.ReadJSON(&matchRequest); err != nil {
 		return matchRequest, err
 	}
+	matchRequest.Port = ws.RemoteAddr().String()
 	log.Printf("Received match request: %v", matchRequest)
 	return matchRequest, nil
 }

--- a/apps/matching-service/main.go
+++ b/apps/matching-service/main.go
@@ -21,7 +21,7 @@ func main() {
 	}
 	port := os.Getenv("PORT")
 
-	// Set up link with redis server
+	// Retrieve redis url env variable and setup the redis client
 	redisAddr := os.Getenv("REDIS_URL")
 	client := redis.NewClient(&redis.Options{
 		Addr:     redisAddr,
@@ -37,8 +37,10 @@ func main() {
 		log.Println("Connected to Redis at the following address: " + redisAddr)
 	}
 
-	// Pass the connect redis client to processes in match
+	// Set redis client
 	processes.SetRedisClient(client)
+
+	// Run a goroutine that matches users
 
 	// Routes
 	http.HandleFunc("/match", handlers.HandleWebSocketConnections)

--- a/apps/matching-service/main.go
+++ b/apps/matching-service/main.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"matching-service/handlers"
+	"matching-service/processes"
 	"net/http"
 	"os"
 
 	"github.com/joho/godotenv"
+	"github.com/redis/go-redis/v9"
 )
 
 func main() {
@@ -17,6 +20,25 @@ func main() {
 		log.Fatalf("err loading: %v", err)
 	}
 	port := os.Getenv("PORT")
+
+	// Set up link with redis server
+	redisAddr := os.Getenv("REDIS_URL")
+	client := redis.NewClient(&redis.Options{
+		Addr:     redisAddr,
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	})
+
+	// Ping the redis server
+	_, err = client.Ping(context.Background()).Result()
+	if err != nil {
+		log.Fatalf("Could not connect to Redis: %v", err)
+	} else {
+		log.Println("Connected to Redis at the following address: " + redisAddr)
+	}
+
+	// Pass the connect redis client to processes in match
+	processes.SetRedisClient(client)
 
 	// Routes
 	http.HandleFunc("/match", handlers.HandleWebSocketConnections)

--- a/apps/matching-service/models/match.go
+++ b/apps/matching-service/models/match.go
@@ -4,11 +4,14 @@ type MatchRequest struct {
 	Type         string   `json:"type"`
 	Topics       []string `json:"topics"`
 	Difficulties []string `json:"difficulties"`
+	Username     string   `json:"username"`
+	Email        string   `json:"email"`
+	Port         string   `json:"port"`
 }
 
 type MatchFound struct {
 	Type        string `json:"type"`
-	MatchID     int64  `json:"matchId"`
+	MatchID     string `json:"matchId"`
 	PartnerID   int64  `json:"partnerId"`
 	PartnerName string `json:"partnerName"`
 }

--- a/apps/matching-service/models/match.go
+++ b/apps/matching-service/models/match.go
@@ -5,18 +5,23 @@ type MatchRequest struct {
 	Topics       []string `json:"topics"`
 	Difficulties []string `json:"difficulties"`
 	Username     string   `json:"username"`
-	Email        string   `json:"email"`
-	Port         string   `json:"port"`
 }
 
 type MatchFound struct {
 	Type        string `json:"type"`
 	MatchID     string `json:"matchId"`
-	PartnerID   int64  `json:"partnerId"`
-	PartnerName string `json:"partnerName"`
+	User        string `json:"user"`        // username
+	MatchedUser string `json:"matchedUser"` // matched username
+	Topic       string `json:"topic"`       // matched topic
+	Difficulty  string `json:"difficulty"`  // matched difficulty
 }
 
 type Timeout struct {
 	Type    string `json:"timeout"`
+	Message string `json:"message"`
+}
+
+type MatchRejected struct {
+	Type    string `json:"type"`
 	Message string `json:"message"`
 }

--- a/apps/matching-service/models/match.go
+++ b/apps/matching-service/models/match.go
@@ -17,7 +17,7 @@ type MatchFound struct {
 }
 
 type Timeout struct {
-	Type    string `json:"timeout"`
+	Type    string `json:"type"`
 	Message string `json:"message"`
 }
 

--- a/apps/matching-service/processes/match.go
+++ b/apps/matching-service/processes/match.go
@@ -2,34 +2,87 @@ package processes
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"matching-service/models"
-	"time"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/redis/go-redis/v9"
 )
 
-// PerformMatching reads the match request and simulates a matching process.
-func PerformMatching(matchRequest models.MatchRequest, ctx context.Context, matchFoundChan chan models.MatchFound) {
-	defer close(matchFoundChan) // Safely close the channel after matching completes.
+var (
+	redisClient *redis.Client
+	mu          sync.Mutex
+)
 
-	// TODO: matching algorithm
-	// for {
-	// 	select {
-	// 	case <-ctx.Done():
-	// 		// The context has been cancelled, so stop the matching process.
-	// 		return
-	// 	default:
-	// 		// Continue matching logic...
-	// 	}
-	// }
-	// Simulate the matching process with a sleep (replace with actual logic).
-	time.Sleep(2 * time.Second)
+// SetRedisClient sets the Redis client to a global variable
+func SetRedisClient(client *redis.Client) {
+	redisClient = client
+}
 
-	// Create a mock result and send it to the channel.
-	result := models.MatchFound{
-		Type:        "match_found",
-		MatchID:     67890,
-		PartnerID:   54321,
-		PartnerName: "John Doe",
+func getPortNumber(addr string) (int64, error) {
+	// Split the string by the colon
+	parts := strings.Split(addr, ":")
+	if len(parts) < 2 {
+		return 0, fmt.Errorf("no port number found")
 	}
 
-	matchFoundChan <- result
+	// Convert the port string to an integer
+	port, err := strconv.ParseInt(parts[len(parts)-1], 10, 64)
+	if err != nil {
+		return 0, err // Return an error if conversion fails
+	}
+
+	return port, nil
+}
+
+func PerformMatching(matchRequest models.MatchRequest, ctx context.Context, matchFoundChan chan models.MatchFound) {
+	defer close(matchFoundChan) // Safely close the channel after matching completes
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Cleaning up, dequeue the user
+			err := dequeueUser(redisClient, matchRequest)
+			if err != nil {
+				log.Println("Failed to dequeue user:", err)
+			}
+
+			return
+
+		default:
+			// Continue matching logic...
+			mu.Lock()
+			match, err := matchUser(redisClient, matchRequest)
+			mu.Unlock()
+			if err != nil {
+				log.Println("Error occurred during matching:", err)
+				return
+			}
+
+			if match != "" {
+				arr := strings.Split(match, ",")
+				username := arr[0]
+				// email := arr[1]
+				port := arr[2]
+				matchId := arr[3]
+				partnerPort, err := getPortNumber(port)
+				if err != nil {
+					log.Println("Error occurred while getting PartnerID:", err)
+					return
+				}
+
+				result := models.MatchFound{
+					Type:        "match_found",
+					MatchID:     matchId,
+					PartnerID:   partnerPort, // Use the retrieved PartnerID
+					PartnerName: username,
+				}
+				matchFoundChan <- result
+				return
+			}
+		}
+	}
 }

--- a/apps/matching-service/processes/queue.go
+++ b/apps/matching-service/processes/queue.go
@@ -1,0 +1,112 @@
+package processes
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"matching-service/models"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var ctx = context.Background()
+
+func generateMatchID() (string, error) {
+	// Create a byte slice to hold random data
+	b := make([]byte, 16) // 16 bytes = 128 bits
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+
+	// Encode the byte slice to a hexadecimal string
+	matchID := hex.EncodeToString(b)
+	return matchID, nil
+}
+
+func enqueueUser(client *redis.Client, request models.MatchRequest) error {
+	// Generate the key for storing in redis
+	key := fmt.Sprintf("queue:%s:%s", request.Topics, request.Difficulties)
+
+	// Concatenate the username,email,port
+	value := fmt.Sprintf("%s,%s,%s", request.Username, request.Email, request.Port)
+
+	// Push the user into the matching queue
+	return client.LPush(ctx, key, value).Err()
+}
+
+func dequeueUser(client *redis.Client, request models.MatchRequest) error {
+	// Generate the key for storing in redis
+	key := fmt.Sprintf("queue:%s:%s", request.Topics, request.Difficulties)
+
+	value := fmt.Sprintf("%s,%s,%s", request.Username, request.Email, request.Port)
+
+	// Remove user from the matching queue
+	_, err := client.LRem(ctx, key, 1, value).Result()
+	return err
+}
+
+func matchUser(client *redis.Client, request models.MatchRequest) (string, error) {
+	key := fmt.Sprintf("queue:%s:%s", request.Topics, request.Difficulties)
+	value := fmt.Sprintf("%s,%s,%s", request.Username, request.Email, request.Port)
+
+	// Check if the user is already matched
+	exists, err := client.HExists(ctx, value, "username").Result()
+	if err != nil {
+		return "", err
+	}
+
+	if exists {
+		// User is already matched, retrieve their details
+		matchedUser, err := client.HGetAll(ctx, value).Result()
+		if err != nil {
+			return "", err
+		}
+
+		// Remove from Redis once retrieved
+		_, err = client.Del(ctx, value).Result()
+		if err != nil {
+			return "", err
+		}
+
+		return fmt.Sprintf("%s,%s,%s,%s", matchedUser["username"], matchedUser["email"], matchedUser["port"], matchedUser["matchid"]), nil
+	}
+
+	match, err := client.RPop(ctx, key).Result()
+
+	if err == redis.Nil {
+		// No match found, enqueue user and return nil
+		enqueueUser(client, request)
+		return "", nil
+	} else if err != nil {
+		return "", err
+	}
+
+	// Check if the matched user is the same as the requesting user
+	if match == value {
+		// If matched user is the same, you can push it back to the queue and try again
+		client.LPush(ctx, key, match) // Re-add the matched user back to the queue
+		return "", nil
+	}
+
+	// Randomly create a matchid
+	matchID, err := generateMatchID()
+	if err != nil {
+		fmt.Println("Error generating match ID:", err)
+		return "", err
+	}
+
+	// Store matched user details in a hash
+	err = client.HSet(ctx, match, map[string]interface{}{
+		"username": request.Username,
+		"email":    request.Email,
+		"port":     request.Port,
+		"matchid":  matchID,
+	}).Err()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s,%s", match, matchID), nil
+}

--- a/apps/matching-service/processes/queue.go
+++ b/apps/matching-service/processes/queue.go
@@ -4,109 +4,326 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"log"
 	"matching-service/models"
+	"strings"
+	"sync"
 
 	"github.com/redis/go-redis/v9"
 )
 
-var ctx = context.Background()
+var mutex sync.Mutex // Mutex for concurrency safety
 
-func generateMatchID() (string, error) {
-	// Create a byte slice to hold random data
+// To simulate generating a random matchID for collaboration service (TODO: Future)
+func GenerateMatchID() (string, error) {
 	b := make([]byte, 16) // 16 bytes = 128 bits
 	_, err := rand.Read(b)
 	if err != nil {
 		return "", err
 	}
-
-	// Encode the byte slice to a hexadecimal string
 	matchID := hex.EncodeToString(b)
 	return matchID, nil
 }
 
-func enqueueUser(client *redis.Client, request models.MatchRequest) error {
-	// Generate the key for storing in redis
-	key := fmt.Sprintf("queue:%s:%s", request.Topics, request.Difficulties)
+// Print existing users in the matching queue
+func PrintMatchingQueue(client *redis.Client, status string, ctx context.Context) {
+	mutex.Lock()
+	defer mutex.Unlock()
 
-	// Concatenate the username,email,port
-	value := fmt.Sprintf("%s,%s,%s", request.Username, request.Email, request.Port)
+	users, err := client.LRange(ctx, "matchmaking_queue", 0, -1).Result()
+	if err != nil {
+		log.Println("Error retrieving users from queue:", err)
+		return
+	}
 
-	// Push the user into the matching queue
-	return client.LPush(ctx, key, value).Err()
+	var concatenatedUsers strings.Builder
+	for i, user := range users {
+		concatenatedUsers.WriteString(user)
+		if i != len(users)-1 {
+			concatenatedUsers.WriteString(", ")
+		}
+	}
+
+	log.Println("Redis Queue (" + status + "): " + concatenatedUsers.String())
 }
 
-func dequeueUser(client *redis.Client, request models.MatchRequest) error {
-	// Generate the key for storing in redis
-	key := fmt.Sprintf("queue:%s:%s", request.Topics, request.Difficulties)
+//
 
-	value := fmt.Sprintf("%s,%s,%s", request.Username, request.Email, request.Port)
+// Enqueue a user into the matchmaking queue
+func EnqueueUser(client *redis.Client, username string, ctx context.Context) {
+	mutex.Lock()
+	defer mutex.Unlock()
 
-	// Remove user from the matching queue
-	_, err := client.LRem(ctx, key, 1, value).Result()
-	return err
+	key := "matchmaking_queue"
+	err := client.LPush(ctx, key, username).Err()
+	if err != nil {
+		log.Println("Error enqueuing user:", err)
+	}
 }
 
-func matchUser(client *redis.Client, request models.MatchRequest) (string, error) {
-	key := fmt.Sprintf("queue:%s:%s", request.Topics, request.Difficulties)
-	value := fmt.Sprintf("%s,%s,%s", request.Username, request.Email, request.Port)
+// Remove user from the matchmaking queue
+func DequeueUser(client *redis.Client, username string, ctx context.Context) {
+	mutex.Lock()
+	defer mutex.Unlock()
 
-	// Check if the user is already matched
-	exists, err := client.HExists(ctx, value, "username").Result()
+	key := "matchmaking_queue"
+	err := client.LRem(ctx, key, 1, username).Err()
 	if err != nil {
-		return "", err
+		log.Println("Error dequeuing user:", err)
 	}
+}
 
-	if exists {
-		// User is already matched, retrieve their details
-		matchedUser, err := client.HGetAll(ctx, value).Result()
+// Add user into each specified topic set based on the topics selected by users
+func AddUserToTopicSets(client *redis.Client, request models.MatchRequest, ctx context.Context) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	for _, topic := range request.Topics {
+		err := client.SAdd(ctx, strings.ToLower(topic), request.Username).Err()
 		if err != nil {
-			return "", err
+			log.Println("Error adding user to topic set:", err)
 		}
-
-		// Remove from Redis once retrieved
-		_, err = client.Del(ctx, value).Result()
-		if err != nil {
-			return "", err
-		}
-
-		return fmt.Sprintf("%s,%s,%s,%s", matchedUser["username"], matchedUser["email"], matchedUser["port"], matchedUser["matchid"]), nil
 	}
+}
 
-	match, err := client.RPop(ctx, key).Result()
+// Remove user from each specified topic set based on the topics selected by users
+func RemoveUserFromTopicSets(client *redis.Client, username string, ctx context.Context) {
+	mutex.Lock()
+	defer mutex.Unlock()
 
-	if err == redis.Nil {
-		// No match found, enqueue user and return nil
-		enqueueUser(client, request)
-		return "", nil
-	} else if err != nil {
-		return "", err
-	}
-
-	// Check if the matched user is the same as the requesting user
-	if match == value {
-		// If matched user is the same, you can push it back to the queue and try again
-		client.LPush(ctx, key, match) // Re-add the matched user back to the queue
-		return "", nil
-	}
-
-	// Randomly create a matchid
-	matchID, err := generateMatchID()
+	request, err := GetUserDetails(client, username, ctx)
 	if err != nil {
-		fmt.Println("Error generating match ID:", err)
-		return "", err
+		log.Println("Error retrieving user from hashset:", err)
+		return
 	}
 
-	// Store matched user details in a hash
-	err = client.HSet(ctx, match, map[string]interface{}{
-		"username": request.Username,
-		"email":    request.Email,
-		"port":     request.Port,
-		"matchid":  matchID,
+	for _, topic := range request.Topics {
+		err := client.SRem(ctx, strings.ToLower(topic), request.Username).Err()
+		if err != nil {
+			log.Println("Error removing user from topic set:", err)
+		}
+	}
+}
+
+// Add user details into hashset in Redis
+func StoreUserDetails(client *redis.Client, request models.MatchRequest, ctx context.Context) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	topicsJSON, err := json.Marshal(request.Topics)
+	if err != nil {
+		log.Println("Error marshalling topics:", err)
+		return
+	}
+
+	difficultiesJSON, err := json.Marshal(request.Difficulties)
+	if err != nil {
+		log.Println("Error marshalling difficulties:", err)
+		return
+	}
+
+	err = client.HSet(ctx, request.Username, map[string]interface{}{
+		"topics":     topicsJSON,
+		"difficulty": difficultiesJSON,
+		"username":   request.Username,
 	}).Err()
 	if err != nil {
-		return "", err
+		log.Println("Error storing user details:", err)
+	}
+}
+
+// Retrieve user details from hashset in Redis
+func GetUserDetails(client *redis.Client, username string, ctx context.Context) (models.MatchRequest, error) {
+	userDetails, err := client.HGetAll(ctx, username).Result()
+	if err != nil {
+		return models.MatchRequest{}, err
 	}
 
-	return fmt.Sprintf("%s,%s", match, matchID), nil
+	if len(userDetails) == 0 {
+		return models.MatchRequest{}, fmt.Errorf("user not found in hashset: %s", username)
+	}
+
+	topicsJSON, topicsExist := userDetails["topics"]
+	difficultiesJSON, difficultiesExist := userDetails["difficulty"]
+
+	if !topicsExist || !difficultiesExist {
+		return models.MatchRequest{}, fmt.Errorf("incomplete user details for: %s", username)
+	}
+
+	var topics []string
+	err = json.Unmarshal([]byte(topicsJSON), &topics)
+	if err != nil {
+		return models.MatchRequest{}, fmt.Errorf("error unmarshalling topics: %v", err)
+	}
+
+	var difficulties []string
+	err = json.Unmarshal([]byte(difficultiesJSON), &difficulties)
+	if err != nil {
+		return models.MatchRequest{}, fmt.Errorf("error unmarshalling difficulties: %v", err)
+	}
+
+	matchRequest := models.MatchRequest{
+		Topics:       topics,
+		Difficulties: difficulties,
+		Username:     username,
+	}
+
+	return matchRequest, nil
+}
+
+// Remove user details from HashSet
+func RemoveUserDetails(client *redis.Client, username string, ctx context.Context) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	err := client.Del(ctx, username).Err()
+	if err != nil {
+		log.Println("Error removing user details:", err)
+	}
+}
+
+// Find the first matching user based on topics
+func FindMatchingUser(client *redis.Client, username string, ctx context.Context) (string, string, string, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	user, err := GetUserDetails(client, username, ctx)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	for _, topic := range user.Topics {
+		users, err := client.SMembers(ctx, strings.ToLower(topic)).Result()
+		if err != nil {
+			return "", "", "", err
+		}
+
+		for _, potentialMatch := range users {
+			if potentialMatch != username {
+				matchedUser, err := GetUserDetails(client, potentialMatch, ctx)
+				if err != nil {
+					return "", "", "", err
+				}
+
+				commonDifficulty := GetCommonDifficulty(user.Difficulties, matchedUser.Difficulties)
+				return potentialMatch, topic, commonDifficulty, nil
+			}
+		}
+	}
+
+	return "", "", "", nil
+}
+
+// Get the highest common difficulty between two users, if no common difficulty found, choose the min of the 2 arrays
+func GetCommonDifficulty(userArr []string, matchedUserArr []string) string {
+	commonDifficulties := make([]int, 3)
+	for i := range commonDifficulties {
+		commonDifficulties[i] = 0
+	}
+
+	for _, difficulty := range userArr {
+		formattedDifficulty := strings.ToLower(difficulty)
+		switch formattedDifficulty {
+		case "easy":
+			commonDifficulties[0]++
+		case "medium":
+			commonDifficulties[1]++
+		case "hard":
+			commonDifficulties[2]++
+		default:
+			log.Println("Unknown difficulty specified: " + difficulty)
+		}
+	}
+
+	for _, difficulty := range matchedUserArr {
+		formattedDifficulty := strings.ToLower(difficulty)
+		switch formattedDifficulty {
+		case "easy":
+			commonDifficulties[0]++
+		case "medium":
+			commonDifficulties[1]++
+		case "hard":
+			commonDifficulties[2]++
+		default:
+			log.Println("Unknown difficulty specified: " + difficulty)
+		}
+	}
+
+	lowest := "Hard"
+	for i := 2; i >= 0; i-- {
+		if commonDifficulties[i] == 2 {
+			switch i {
+			case 0:
+				return "Easy"
+			case 1:
+				return "Medium"
+			case 2:
+				return "Hard"
+			}
+		} else if commonDifficulties[i] > 0 {
+			switch i {
+			case 0:
+				lowest = "Easy"
+			case 1:
+				lowest = "Medium"
+			case 2:
+				lowest = "Hard"
+			}
+		}
+	}
+	return lowest
+}
+
+func CleanUpUser(client *redis.Client, username string, ctx context.Context) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	// Dequeue user
+	key := "matchmaking_queue"
+	err := client.LRem(ctx, key, 1, username).Err()
+	if err != nil {
+		log.Println("Error dequeuing user:", err)
+	}
+
+	// Remove user from topic sets
+	request, err := GetUserDetails(client, username, ctx)
+	if err != nil {
+		log.Println("Error retrieving user from hashset:", err)
+		return
+	}
+
+	for _, topic := range request.Topics {
+		err := client.SRem(ctx, strings.ToLower(topic), request.Username).Err()
+		if err != nil {
+			log.Println("Error removing user from topic set:", err)
+		}
+	}
+
+	// Remove user details
+	err = client.Del(ctx, username).Err()
+	if err != nil {
+		log.Println("Error removing user details:", err)
+	}
+	return
+}
+
+func PopAndInsert(client *redis.Client, username string, ctx context.Context) {
+	// Acquire Lock
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	// Pop user
+	username, err := client.LPop(ctx, "matchmaking_queue").Result()
+	if err != nil {
+		log.Println("Error popping user from queue:", err)
+	}
+
+	// Insert back in queue
+	key := "matchmaking_queue"
+	err = client.LPush(ctx, key, username).Err()
+	if err != nil {
+		log.Println("Error enqueuing user:", err)
+	}
+	return
 }

--- a/apps/matching-service/tests/websocket-test.html
+++ b/apps/matching-service/tests/websocket-test.html
@@ -42,8 +42,8 @@
               type: "match_request",
               topics: ["Algorithms", "Arrays"],
               difficulties: ["Easy", "Medium"],
+              // username: "JohnDoe", // Uncomment for same user test for rejection
               username: arr[0],
-              email: arr[1],
             })
           );
 

--- a/apps/matching-service/tests/websocket-test.html
+++ b/apps/matching-service/tests/websocket-test.html
@@ -1,66 +1,83 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Matching service: websocket test</title>
-</head>
-<body>
+  </head>
+  <body>
     <p id="status">Status: no matching yet</p>
     <button onclick="openWebSocket()">Find match</button>
     <button onclick="closeConnection()">Cancel matching</button>
     <p id="response"></p>
     <script>
-        let socket = null;
-        
-        function openWebSocket() {
-            // Connect to WebSocket server
-            // User should be authenticated first
-            // JWT token should be sent with the initial request, in the authorization header.
-            // request would be checked as middleware.
-            if (socket != null) return
-            socket = new WebSocket("ws://localhost:8081/match");
-            document.getElementById("response").innerText = ""; 
+      let socket = null;
 
-            // Log connection opening
-            socket.onopen = function() {
-                console.log("WebSocket is open now.");
-                
-                // send the match request when connection is open
-                socket.send(JSON.stringify({
-                    type: "match_request",
-                    topics: ["Algorithms", "Arrays"],
-                    difficulties: ["Easy", "Medium"],
-                }))
+      function generateRandomDetails() {
+        const username = Math.random().toString(36).substring(2, 8); // Generates a random username
+        const domains = ["example.com", "mail.com", "test.com"];
+        const domain = domains[Math.floor(Math.random() * domains.length)];
+        return [username, `${username}@${domain}`];
+      }
 
-                document.getElementById("status").innerText = "Status: matching in progress..."
-            };
-            
-            // Log response message and display it
-            socket.onmessage = function(event) {
-                console.log("Message received: " + event.data);
-                document.getElementById("response").innerText = "Received: " + event.data;
-            document.getElementById("status").innerText = "Status: matching found/timeout"
+      function openWebSocket() {
+        // Connect to WebSocket server
+        // User should be authenticated first
+        // JWT token should be sent with the initial request, in the authorization header.
+        // request would be checked as middleware.
+        if (socket != null) return;
+        socket = new WebSocket("ws://localhost:8081/match");
+        document.getElementById("response").innerText = "";
 
-            };
-            
-            // Log errors
-            socket.onerror = function(error) {
-                console.log("WebSocket error: " + error);
-            };
-            
-            // Log connection closure
-            socket.onclose = function() {
-                console.log("WebSocket is closed now.");
-                socket = null
-            };
-        }
-        
-        function closeConnection() {
-            document.getElementById("status").innerText = "Status: matching cancelled"
-            document.getElementById("response").innerText = ""; 
-            socket.close();
-        }
+        // Log connection opening
+        socket.onopen = function () {
+          console.log("WebSocket is open now.");
+
+          // Random email & username
+          const arr = generateRandomDetails();
+
+          // send the match request when connection is open
+          socket.send(
+            JSON.stringify({
+              type: "match_request",
+              topics: ["Algorithms", "Arrays"],
+              difficulties: ["Easy", "Medium"],
+              username: arr[0],
+              email: arr[1],
+            })
+          );
+
+          document.getElementById("status").innerText =
+            "Status: matching in progress...";
+        };
+
+        // Log response message and display it
+        socket.onmessage = function (event) {
+          console.log("Message received: " + event.data);
+          document.getElementById("response").innerText =
+            "Received: " + event.data;
+          document.getElementById("status").innerText =
+            "Status: matching found/timeout";
+        };
+
+        // Log errors
+        socket.onerror = function (error) {
+          console.log("WebSocket error: " + error);
+        };
+
+        // Log connection closure
+        socket.onclose = function () {
+          console.log("WebSocket is closed now.");
+          socket = null;
+        };
+      }
+
+      function closeConnection() {
+        document.getElementById("status").innerText =
+          "Status: matching cancelled";
+        document.getElementById("response").innerText = "";
+        socket.close();
+      }
     </script>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
Change the logic of matching service:
- Users get added into a matchmaking queue
- At the same time, we add their username into topic Sets in Redis and store their matching request information in a HashSet in Redis
- Peek at front of the queue --> retrieve user info from hash --> Loop through topics set (based on user's specified topics) one by one and try to find the first match --> return match (if any) together with the common topic and difficulty --> trigger a notifyMatch function to send result to both websockets --> attempt to close both websockets context

Added new type match_rejected when a user within an existing queue tries to matchmake again @chiaryan @solomonng2001 can take note of this for frontend. Refer to README.md for more details.

Current Situation:
- There is a bug where after the matched user gets informed, the matchCtx fails to cancel even though the cancelFunc() is called, resulting in retrieving of match_found then subsequently timeout caused by the timeoutCtx.
@tituschewxj need your help to checkout my branch and `apps/matching-service/handlers/websocket.go`

After resolving the problem, we should be able to merge 👍 