### PR TITLE
fix: python sandbox naming

### DIFF
--- a/apps/execution-service/execution/python/python.go
+++ b/apps/execution-service/execution/python/python.go
@@ -11,7 +11,7 @@ func RunPythonCode(code string, input string) (string, string, error) {
 	cmd := exec.Command(
 		"docker", "run", "--rm",
 		"-i", // allows for standard input to be passed in
-		"apps-python-sandbox",
+		"apps_python-sandbox",
 		"python", "-c", code,
 	)
 


### PR DESCRIPTION
The naming for the python sandbox should be prefixed with "apps_" instead of "apps-".