### PR TITLE
feat: add session status tooltip

### DIFF
--- a/apps/frontend/src/app/collaboration/[id]/page.tsx
+++ b/apps/frontend/src/app/collaboration/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
   Tag,
   Typography,
   Spin,
+  Tooltip,
 } from "antd";
 import { Content } from "antd/es/layout/layout";
 import "./styles.scss";
@@ -492,7 +493,9 @@ export default function CollaborationPage(props: CollaborationProps) {
                   />
                 )}
                 <div className="hidden-test-results">
-                  <InfoCircleFilled className="hidden-test-icon" />
+                  <Tooltip title="Status applies only to this session">
+                    <InfoCircleFilled className="hidden-test-icon" />
+                  </Tooltip>
                   <Typography.Text
                     strong
                     style={{


### PR DESCRIPTION
Add session tool tip to emphasise that the status only applies to this session and not the entirety of the user's history

<img width="1728" alt="Screenshot 2024-11-13 at 6 45 31 PM" src="https://github.com/user-attachments/assets/7d3306f7-447d-47bc-9358-dac2bca659f1">
